### PR TITLE
ENH Auto refresh search results page

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -8,6 +8,7 @@
         "direct": {
             "NoRedInk/elm-simple-fuzzy": "1.0.3",
             "abinayasudhir/elm-select": "1.3.0",
+            "andrewMacmurray/elm-delay": "4.0.0",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",


### PR DESCRIPTION
This also refactored the Mapper page to reduce complexity: the results of the initial call to start the search and the status updates can be processed using the same code paths (including the same JSON decoder).